### PR TITLE
增加自动执行git commit和自动删除旧的工作流

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: user
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@main
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@main
         with:
           node-version: 18
       - name: init secrets
@@ -30,8 +30,23 @@ jobs:
         run: npm install
       - name: run
         id: run
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@master
         with:
           timeout_minutes: 10
           max_attempts: 3
           command: npm start
+      - name: Keep Running
+        run: |
+          git config --local user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          git config --local user.name "${{ github.actor }}"
+          git remote set-url origin https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}
+          git pull --rebase
+          git commit --allow-empty -m "Keep Running..."
+          git push
+      - name: Delete old workflow run
+        uses: Mattraks/delete-workflow-runs@main
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: 0
+          keep_minimum_runs: 0

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -49,4 +49,4 @@ jobs:
           token: ${{ github.token }}
           repository: ${{ github.repository }}
           retain_days: 0
-          keep_minimum_runs: 0
+          keep_minimum_runs: 50

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -40,7 +40,7 @@ jobs:
           git config --local user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
           git config --local user.name "${{ github.actor }}"
           git remote set-url origin https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}
-          git pull --rebase
+          git pull --rebase --autostash
           git commit --allow-empty -m "Keep Running..."
           git push
       - name: Delete old workflow run

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@
 
 ![](https://cdn.jsdelivr.net/gh/wes-lin/Cloud189Checkin/image/fork.png)
 
+### 设置工作流权限
+将Settings -> Actions -> Workflow permissions 改成 Read and write permissions
+![image](https://github.com/user-attachments/assets/28d27a78-73f2-489e-aa7e-cac87c0fc509)
+
+
 ### 设置账号密码
 
 新版本的 git Action 需要创建 environment 来配合使用，创建一个名为 user 的环境。


### PR DESCRIPTION
增加自动执行git commit，不会因为仓库长期不活动导致Github Actions被禁用，和自动删除旧的工作流，可能需要把仓库的 Settings -> Actions -> Workflow permissions 改成 Read and write permissions